### PR TITLE
Generalize Staff type

### DIFF
--- a/src/StaffCard/StaffCard.tsx
+++ b/src/StaffCard/StaffCard.tsx
@@ -3,31 +3,14 @@ import Image from "next/image";
 
 /**
  * Staff card types
- * copied from Pelican website
+ * copied loosely from Pelican website
  */
 
-export type Staff = StaffBase & {
-  [key in StaffOrganizations]?: Partial<StaffBase>;
-};
-
-export type StaffOrganizations =
-  | "htcondor"
-  | "path"
-  | "osg"
-  | "chtc"
-  | "pelican";
-
-export interface StaffBase {
+export interface Staff {
   name: string;
   image: string;
   title: string;
-  website?: string;
   institution?: string;
-  promoted?: boolean;
-  weight?: number;
-  description?: string;
-  status: "Staff" | "Student" | "Past";
-  organizations: StaffOrganizations[];
 }
 
 const StaffCard = ({

--- a/src/StaffCard/index.ts
+++ b/src/StaffCard/index.ts
@@ -1,6 +1,1 @@
-export {
-  default,
-  type Staff,
-  type StaffBase,
-  type StaffOrganizations,
-} from "./StaffCard";
+export { default, type Staff } from "./StaffCard";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,5 @@ export { default as Table, type TableProps } from "./Table";
 export { default as ColorBar } from "./ColorBar";
 export { default as BigNumber, type BigNumberProps } from "./BigNumber";
 export { default as TimeBar } from "./TimeBar";
-export {
-  default as StaffCard,
-  type Staff,
-  type StaffBase,
-  type StaffOrganizations,
-} from "./StaffCard";
+export { default as StaffCard, type Staff } from "./StaffCard";
 export * from "./utils";

--- a/stories/mockData/StaffCard.ts
+++ b/stories/mockData/StaffCard.ts
@@ -5,8 +5,6 @@ export const defaultStaff: Staff = {
   image: "https://placehold.co/150x150",
   title: "Research Software Engineer",
   institution: "University of Wisconsin—Madison",
-  status: "Staff",
-  organizations: ["chtc", "path"],
 };
 
 export const defaultLeader: Staff = {
@@ -14,7 +12,4 @@ export const defaultLeader: Staff = {
   image: "https://placehold.co/150x150",
   title: "Principal Investigator",
   institution: "University of Wisconsin—Madison",
-  status: "Staff",
-  promoted: true,
-  organizations: ["chtc", "path"],
 };


### PR DESCRIPTION
The Staff type was previously copied from the Pelican repo, however there were some irrelevant fields that weren't needed for the card like `organizations`, `promoted`, `weight`, etc.